### PR TITLE
feat: Add docstring to frontend/src/main.jsx

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
+/**
+ * The entry point for the DSR-CRAG frontend application.
+ *
+ * This file initializes the React application, renders the root App component,
+ * and sets up strict mode for development.
+ */
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
This PR adds a docstring to `frontend/src/main.jsx`, clarifying its role as the entry point for the React application.